### PR TITLE
TKT-11058: Add additional_filters param to XSIAM alerts API

### DIFF
--- a/cortex_xdr_client/api/alerts_api.py
+++ b/cortex_xdr_client/api/alerts_api.py
@@ -171,6 +171,7 @@ class AlertsAPI(BaseAPI):
         self,
         alert_ids: list[str] | None = None,
         creation_time: int | None = None,
+        additional_filters: list[dict] | None = None,
         limit: int = 50,
         page: int = 0,
         sort_type: QuerySortType = QuerySortType.CREATION_TIME,
@@ -182,6 +183,7 @@ class AlertsAPI(BaseAPI):
 
         :param alert_ids: List of alert IDs (as strings)
         :param creation_time: Timestamp of the Creation time in milliseconds
+        :param additional_filters: List of additional API-compatible filter dicts to include in the request
         :param limit: Number of alerts per page (max 100)
         :param page: Page number (0-indexed)
         :param sort_type: The field to sort by the requested alerts (default: CREATION_TIME)
@@ -197,6 +199,9 @@ class AlertsAPI(BaseAPI):
             filters.append(
                 request_gte_lte_filter("creation_time", creation_time, True)
             )
+
+        if additional_filters:
+            filters.extend(additional_filters)
 
         limit = min(limit, 100)
         sort = {"field": sort_type, "keyword": sort_order} if sort_type else None
@@ -222,6 +227,7 @@ class AlertsAPI(BaseAPI):
         self,
         alert_ids: list[str] | None = None,
         creation_time: int | None = None,
+        additional_filters: list[dict] | None = None,
         page_size: int = 50,
         max_alerts: int | None = None,
     ) -> list:
@@ -231,6 +237,7 @@ class AlertsAPI(BaseAPI):
 
         :param alert_ids: List of alert IDs (as strings)
         :param creation_time: Timestamp of the Creation time in milliseconds
+        :param additional_filters: List of additional API-compatible filter dicts to include in the request
         :param page_size: Number of alerts per page (max 100)
         :param max_alerts: Maximum number of alerts to return (None for all)
         :return: Returns a list of Alert objects.
@@ -244,6 +251,7 @@ class AlertsAPI(BaseAPI):
             result = self.get_xsiam_alerts(
                 alert_ids=alert_ids,
                 creation_time=creation_time,
+                additional_filters=additional_filters,
                 limit=page_size,
                 page=page,
                 sort_type=QuerySortType.CREATION_TIME,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "cortex-xdr-client"
 packages = [
     { include = "cortex_xdr_client", from = "." },
 ]
-version = "1.9.30-dev"
+version = "1.9.31-dev"
 description = "API client for Cortex XDR Prevent"
 authors = ["ebarti"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Add optional `additional_filters` parameter to `get_xsiam_alerts()` and `get_all_xsiam_alerts()` to support passing arbitrary API-compatible filters to the Cortex XDR alerts endpoint
- Bump version to `1.9.31-dev`

## Context
The LOH Services GmbH Cortex XDR SIEM connector needs to filter out alerts with titles starting with "CVE". This change enables the connector to pass additional filters to the API.

## Test plan
- [ ] Verify existing tests still pass
- [ ] Verify new param is optional and defaults to `None` (no behavior change)

Ref: TKT-11058

🤖 Generated with [Claude Code](https://claude.ai/code)