### PR TITLE
fix(alerts): allow null elements in action_remote_port / action_local_port

### DIFF
--- a/cortex_xdr_client/api/models/alerts.py
+++ b/cortex_xdr_client/api/models/alerts.py
@@ -299,10 +299,10 @@ class AlertV2(CustomBaseModel):
     action_registry_full_key: list[str] | None = None
     action_local_ip: list[str] | None = None
     action_local_ip_v6: list[str] | None = None
-    action_local_port: list[int] | None = None
+    action_local_port: list[int | None] | None = None
     action_remote_ip: list[str] | None = None
     action_remote_ip_v6: list[str] | None = None
-    action_remote_port: list[int] | None = None
+    action_remote_port: list[int | None] | None = None
     action_external_hostname: list[str] | None = None
     action_country: list[str] | None = None
     action_process_instance_id: list[str] | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "cortex-xdr-client"
 packages = [
     { include = "cortex_xdr_client", from = "." },
 ]
-version = "1.9.31-dev"
+version = "1.9.33-dev"
 description = "API client for Cortex XDR Prevent"
 authors = ["ebarti"]
 license = "MIT"


### PR DESCRIPTION
## What
Widen `AlertV2.action_remote_port` and `action_local_port` from `list[int] | None` to `list[int | None] | None`.

## Why
The Cortex XDR / XSIAM public API can return these port fields as a list whose element is `null` (e.g. `[None]`) for alerts that have no associated remote/local port. Because the elements were typed as `int`, pydantic rejected the `null` and failed to validate the **entire** `get_alerts_v2` response, so a single such alert caused a whole page to fail parsing and callers received zero alerts. Widening the element type to `int | None` — consistent with the existing `event_type: list[str | int | None]` field — lets these alerts parse.

## Testing
- Existing test suite passes (`21 passed`).
- Verified against the live Cortex XDR API: `get_alerts_v2` pages that previously failed to validate now parse successfully, including alerts carrying `null` port values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)