### PR TITLE
fix: coerce malicious_urls string to list in Alert and AlertV2 models

### DIFF
--- a/cortex_xdr_client/api/models/alerts.py
+++ b/cortex_xdr_client/api/models/alerts.py
@@ -205,6 +205,7 @@ class Alert(CustomBaseModel):
                      'mitre_technique_id_and_name',
                      'agent_ip_addresses_v6',
                      'mac_address',
+                     'malicious_urls',
                      mode='before')
     @classmethod
     def _split_comma_separated_string_to_list(cls, value: str | list[str] | None) -> list[str] | None:
@@ -397,6 +398,22 @@ class AlertV2(CustomBaseModel):
             return None
         if isinstance(value, list):
             return [str(item) if isinstance(item, int) else item for item in value]
+        return value
+
+    @field_validator('host_ip',
+                     'tags',
+                     'original_tags',
+                     'mitre_tactic_id_and_name',
+                     'mitre_technique_id_and_name',
+                     'agent_ip_addresses_v6',
+                     'malicious_urls',
+                     mode='before')
+    @classmethod
+    def _split_comma_separated_string_to_list(cls, value: str | list[str] | None) -> list[str] | None:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return [item.strip() for item in value.split(',') if item.strip()]
         return value
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "cortex-xdr-client"
 packages = [
     { include = "cortex_xdr_client", from = "." },
 ]
-version = "1.9.33-dev"
+version = "1.9.34-dev"
 description = "API client for Cortex XDR Prevent"
 authors = ["ebarti"]
 license = "MIT"


### PR DESCRIPTION
## Problem

The alerts API can return the `malicious_urls` field as a plain string (for example a single URL) instead of a list. Because the SDK validates the whole response at once, one such alert fails Pydantic validation:

```
Input should be a valid list [type=list_type, input_value='https://...', input_type=str]
```

and the **entire page of alerts is rejected**, not just the offending alert.

## Fix

- Add `malicious_urls` to the existing `_split_comma_separated_string_to_list` field validator on the V1 `Alert` model (it already normalizes `host_ip`, `tags`, `mac_address`, etc.).
- Add the identical validator to the V2 `AlertV2` model, covering the same list-typed fields present there.

Behavior: a single-value string becomes a one-item list, a comma-separated string is split, existing lists pass through unchanged, and `None` stays `None`. Both the V1 (`GetAlertsResponse`) and V2 (`GetAlertsResponseV2`) response paths are exercised in production, so both models are covered.

Version bumped `1.9.33-dev` → `1.9.34-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
